### PR TITLE
fixed a deprecated warning

### DIFF
--- a/src/serf/serf.conf
+++ b/src/serf/serf.conf
@@ -1,2 +1,2 @@
 if $programname == 'serf' then /var/log/serf.log
-if $programname == 'serf' then ~ 
+& stop


### PR DESCRIPTION
rsyslogd: warning: ~ action is deprecated, consider using the 'stop' statement instead [v8.24.0 try http://www.rsyslog.com/e/2307 ]

Feel free to ignore; :)